### PR TITLE
Move printing exception into the exception itself

### DIFF
--- a/src/main/java/com/jonahseguin/drink/command/DrinkCommandService.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkCommandService.java
@@ -177,7 +177,7 @@ public class DrinkCommandService implements CommandService {
             }
         }
         catch (CommandExitMessage ex) {
-            sender.sendMessage(ChatColor.RED + ex.getMessage());
+            ex.print(sender);
         } catch (CommandArgumentException ex) {
             sender.sendMessage(ChatColor.RED + ex.getMessage());
             helpService.sendUsageMessage(sender, getContainerFor(command), command);

--- a/src/main/java/com/jonahseguin/drink/exception/CommandExitMessage.java
+++ b/src/main/java/com/jonahseguin/drink/exception/CommandExitMessage.java
@@ -1,8 +1,15 @@
 package com.jonahseguin.drink.exception;
 
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
 public class CommandExitMessage extends Exception {
 
     public CommandExitMessage(String message) {
         super(message);
+    }
+
+    public void print(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + getMessage());
     }
 }


### PR DESCRIPTION
By moving the code to print the exception inside the CommandExitMessage it can get overridden.
The reason why i would want it to be able get overridden is for the use of my language files.