### PR TITLE
@Require added to class, usage uses parameter name

### DIFF
--- a/src/main/java/com/jonahseguin/drink/annotation/Require.java
+++ b/src/main/java/com/jonahseguin/drink/annotation/Require.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Require {
 
     String value();

--- a/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
+++ b/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
@@ -50,6 +50,9 @@ public class CommandExtractor {
             if (method.isAnnotationPresent(Require.class)) {
                 Require require = method.getAnnotation(Require.class);
                 perm = require.value();
+            } else if (method.getDeclaringClass().isAnnotationPresent(Require.class)) {
+                Require require = method.getDeclaringClass().getAnnotation(Require.class);
+                perm = require.value() + (command.name().isEmpty() ? "" : ".") + command.name();
             }
             DrinkCommand drinkCommand = new DrinkCommand(
                     commandService, command.name(), Sets.newHashSet(command.aliases()), command.desc(), command.usage(),

--- a/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
@@ -75,13 +75,14 @@ public class DrinkCommand {
         for (int i = 0; i < parameters.getParameters().length; i++) {
             CommandParameter parameter = parameters.getParameters()[i];
             DrinkProvider provider = providers[i];
+            String description = parameter.getParameter().getName(); // provider.argumentDescription()
             if (parameter.isFlag()) {
                 sb.append("-").append(parameter.getFlag().value()).append(" ");
             }
             else {
                 if (provider.doesConsumeArgument()) {
                     if (parameter.isOptional()) {
-                        sb.append("[").append(provider.argumentDescription());
+                        sb.append("[").append(description);
                         if (parameter.isText()) {
                             sb.append("...");
                         }
@@ -90,7 +91,7 @@ public class DrinkCommand {
                         }
                         sb.append("]");
                     } else {
-                        sb.append("<").append(provider.argumentDescription());
+                        sb.append("<").append(description);
                         if (parameter.isText()) {
                             sb.append("...");
                         }


### PR DESCRIPTION
Require can be added to outer class and inherit sub-command nodes
Generated usages use parameter names instead of provider's description (-parameter)