### PR TITLE
Multiple @OptArg support

### DIFF
--- a/src/main/java/com/jonahseguin/drink/annotation/Command.java
+++ b/src/main/java/com/jonahseguin/drink/annotation/Command.java
@@ -17,4 +17,5 @@ public @interface Command {
 
     String usage() default "";
 
+	boolean async() default false;
 }

--- a/src/main/java/com/jonahseguin/drink/annotation/OptArg.java
+++ b/src/main/java/com/jonahseguin/drink/annotation/OptArg.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@LastArg
 public @interface OptArg {
 
     String value() default "";

--- a/src/main/java/com/jonahseguin/drink/argument/CommandArgs.java
+++ b/src/main/java/com/jonahseguin/drink/argument/CommandArgs.java
@@ -47,6 +47,16 @@ public class CommandArgs {
         }
     }
 
+	public void skip() {
+		lock.lock();
+		try {
+			index--;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
     public String next() {
         lock.lock();
         try {

--- a/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
+++ b/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
@@ -16,51 +16,50 @@ import java.util.Optional;
 
 public class CommandExtractor {
 
-    private final DrinkCommandService commandService;
+	private final DrinkCommandService commandService;
 
-    public CommandExtractor(DrinkCommandService commandService) {
-        this.commandService = commandService;
-    }
+	public CommandExtractor(DrinkCommandService commandService) {
+		this.commandService = commandService;
+	}
 
-    public Map<String, DrinkCommand> extractCommands(@Nonnull Object handler) throws MissingProviderException, CommandStructureException {
-        Preconditions.checkNotNull(handler, "Handler object cannot be null");
-        final Map<String, DrinkCommand> commands = new HashMap<>();
-        for (Method method : handler.getClass().getDeclaredMethods()) {
-            Optional<DrinkCommand> o = extractCommand(handler, method);
-            if (o.isPresent()) {
-                DrinkCommand drinkCommand = o.get();
-                commands.put(commandService.getCommandKey(drinkCommand.getName()), drinkCommand);
-            }
-        }
-        return commands;
-    }
+	public Map<String, DrinkCommand> extractCommands(@Nonnull Object handler) throws MissingProviderException, CommandStructureException {
+		Preconditions.checkNotNull(handler, "Handler object cannot be null");
+		final Map<String, DrinkCommand> commands = new HashMap<>();
+		for (Method method : handler.getClass().getDeclaredMethods()) {
+			Optional<DrinkCommand> o = extractCommand(handler, method);
+			if (o.isPresent()) {
+				DrinkCommand drinkCommand = o.get();
+				commands.put(commandService.getCommandKey(drinkCommand.getName()), drinkCommand);
+			}
+		}
+		return commands;
+	}
 
-    private Optional<DrinkCommand> extractCommand(@Nonnull Object handler, @Nonnull Method method) throws MissingProviderException, CommandStructureException {
-        Preconditions.checkNotNull(handler, "Handler object cannot be null");
-        Preconditions.checkNotNull(method, "Method cannot be null");
-        if (method.isAnnotationPresent(Command.class)) {
-            try {
-                method.setAccessible(true);
-            }
-            catch (SecurityException ex) {
-                throw new CommandRegistrationException("Couldn't access method " + method.getName());
-            }
-            Command command = method.getAnnotation(Command.class);
-            String perm = "";
-            if (method.isAnnotationPresent(Require.class)) {
-                Require require = method.getAnnotation(Require.class);
-                perm = require.value();
-            } else if (method.getDeclaringClass().isAnnotationPresent(Require.class)) {
-                Require require = method.getDeclaringClass().getAnnotation(Require.class);
-                perm = require.value() + (command.name().isEmpty() ? "" : ".") + command.name();
-            }
-            DrinkCommand drinkCommand = new DrinkCommand(
-                    commandService, command.name(), Sets.newHashSet(command.aliases()), command.desc(), command.usage(),
-                    perm, handler, method
-            );
-            return Optional.of(drinkCommand);
-        }
-        return Optional.empty();
-    }
+	private Optional<DrinkCommand> extractCommand(@Nonnull Object handler, @Nonnull Method method) throws MissingProviderException, CommandStructureException {
+		Preconditions.checkNotNull(handler, "Handler object cannot be null");
+		Preconditions.checkNotNull(method, "Method cannot be null");
+		if (method.isAnnotationPresent(Command.class)) {
+			try {
+				method.setAccessible(true);
+			} catch (SecurityException ex) {
+				throw new CommandRegistrationException("Couldn't access method " + method.getName());
+			}
+			Command command = method.getAnnotation(Command.class);
+			String perm = "";
+			if (method.isAnnotationPresent(Require.class)) {
+				Require require = method.getAnnotation(Require.class);
+				perm = require.value();
+			} else if (method.getDeclaringClass().isAnnotationPresent(Require.class)) {
+				Require require = method.getDeclaringClass().getAnnotation(Require.class);
+				perm = require.value() + (command.name().isEmpty() ? "" : ".") + command.name();
+			}
+			DrinkCommand drinkCommand = new DrinkCommand(
+					commandService, command.name(), Sets.newHashSet(command.aliases()), command.desc(), command.usage(), command.async(),
+					perm, handler, method
+			);
+			return Optional.of(drinkCommand);
+		}
+		return Optional.empty();
+	}
 
 }

--- a/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
@@ -30,7 +30,7 @@ public class DrinkCommand {
     private final boolean requiresAsync;
     private final String generatedUsage;
 
-    public DrinkCommand(DrinkCommandService commandService, String name, Set<String> aliases, String description, String usage, String permission, Object handler, Method method) throws MissingProviderException, CommandStructureException {
+    public DrinkCommand(DrinkCommandService commandService, String name, Set<String> aliases, String description, String usage, boolean async, String permission, Object handler, Method method) throws MissingProviderException, CommandStructureException {
         this.commandService = commandService;
         this.name = name;
         this.aliases = aliases;
@@ -44,7 +44,7 @@ public class DrinkCommand {
         this.consumingArgCount = calculateConsumingArgCount();
         this.requiredArgCount = calculateRequiredArgCount();
         this.consumingProviders = calculateConsumingProviders();
-        this.requiresAsync = calculateRequiresAsync();
+        this.requiresAsync = async || calculateRequiresAsync();
         this.generatedUsage = generateUsage();
         this.allAliases = aliases;
         if (name.length() > 0 && !name.equals(DrinkCommandService.DEFAULT_KEY)) {

--- a/src/main/java/com/jonahseguin/drink/parametric/ProviderAssigner.java
+++ b/src/main/java/com/jonahseguin/drink/parametric/ProviderAssigner.java
@@ -17,11 +17,13 @@ public class ProviderAssigner {
         CommandParameters parameters = drinkCommand.getParameters();
         DrinkProvider<?>[] providers = new DrinkProvider<?>[parameters.getParameters().length];
         for (int i = 0; i < parameters.getParameters().length; i++) {
-            CommandParameter param = parameters.getParameters()[i];
+
+			CommandParameter param = parameters.getParameters()[i];
             if (param.isRequireLastArg() && !parameters.isLastArgument(i)) {
                 throw new CommandStructureException("Parameter " + param.getParameter().getName() + " [argument " + i + "] (" + param.getParameter().getType().getSimpleName() + ") in method '" + drinkCommand.getMethod().getName() + "' must be the last argument in the method.");
             }
-            BindingContainer<?> bindings = commandService.getBindingsFor(param.getType());
+
+			BindingContainer<?> bindings = commandService.getBindingsFor(param.getType());
             if (bindings != null) {
                 DrinkProvider<?> provider = null;
                 for (DrinkBinding<?> binding : bindings.getBindings()) {

--- a/src/main/java/com/jonahseguin/drink/parametric/ProviderAssigner.java
+++ b/src/main/java/com/jonahseguin/drink/parametric/ProviderAssigner.java
@@ -7,43 +7,41 @@ import com.jonahseguin.drink.exception.MissingProviderException;
 
 public class ProviderAssigner {
 
-    private final DrinkCommandService commandService;
+	private final DrinkCommandService commandService;
 
-    public ProviderAssigner(DrinkCommandService commandService) {
-        this.commandService = commandService;
-    }
+	public ProviderAssigner(DrinkCommandService commandService) {
+		this.commandService = commandService;
+	}
 
-    public DrinkProvider<?>[] assignProvidersFor(DrinkCommand drinkCommand) throws MissingProviderException, CommandStructureException {
-        CommandParameters parameters = drinkCommand.getParameters();
-        DrinkProvider<?>[] providers = new DrinkProvider<?>[parameters.getParameters().length];
-        for (int i = 0; i < parameters.getParameters().length; i++) {
+	public DrinkProvider<?>[] assignProvidersFor(DrinkCommand drinkCommand) throws MissingProviderException, CommandStructureException {
+		CommandParameters parameters = drinkCommand.getParameters();
+		DrinkProvider<?>[] providers = new DrinkProvider<?>[parameters.getParameters().length];
+		for (int i = 0; i < parameters.getParameters().length; i++) {
 
 			CommandParameter param = parameters.getParameters()[i];
-            if (param.isRequireLastArg() && !parameters.isLastArgument(i)) {
-                throw new CommandStructureException("Parameter " + param.getParameter().getName() + " [argument " + i + "] (" + param.getParameter().getType().getSimpleName() + ") in method '" + drinkCommand.getMethod().getName() + "' must be the last argument in the method.");
-            }
+			if (param.isRequireLastArg() && !parameters.isLastArgument(i)) {
+				throw new CommandStructureException("Parameter " + param.getParameter().getName() + " [argument " + i + "] (" + param.getParameter().getType().getSimpleName() + ") in method '" + drinkCommand.getMethod().getName() + "' must be the last argument in the method.");
+			}
 
 			BindingContainer<?> bindings = commandService.getBindingsFor(param.getType());
-            if (bindings != null) {
-                DrinkProvider<?> provider = null;
-                for (DrinkBinding<?> binding : bindings.getBindings()) {
-                    if (binding.canProvideFor(param)) {
-                        provider = binding.getProvider();
-                        break;
-                    }
-                }
-                if (provider != null) {
-                    providers[i] = provider;
-                }
-                else {
-                    throw new MissingProviderException("No provider bound for " + param.getType().getSimpleName() + " for parameter " + i + " for method " + drinkCommand.getMethod().getName());
-                }
-            }
-            else {
-                throw new MissingProviderException("No provider bound for " + param.getType().getSimpleName());
-            }
-        }
-        return providers;
-    }
+			if (bindings != null) {
+				DrinkProvider<?> provider = null;
+				for (DrinkBinding<?> binding : bindings.getBindings()) {
+					if (binding.canProvideFor(param)) {
+						provider = binding.getProvider();
+						break;
+					}
+				}
+				if (provider != null) {
+					providers[i] = provider;
+				} else {
+					throw new MissingProviderException("No provider bound for " + param.getType().getSimpleName() + " for parameter " + i + " for method " + drinkCommand.getMethod().getName());
+				}
+			} else {
+				throw new MissingProviderException("No provider bound for " + param.getType().getSimpleName());
+			}
+		}
+		return providers;
+	}
 
 }

--- a/src/main/java/com/jonahseguin/drink/provider/TextProvider.java
+++ b/src/main/java/com/jonahseguin/drink/provider/TextProvider.java
@@ -21,6 +21,11 @@ public class TextProvider extends DrinkProvider<String> {
     }
 
     @Override
+    public boolean allowNullArgument() {
+        return false;
+    }
+
+    @Override
     public boolean isAsync() {
         return false;
     }


### PR DESCRIPTION
I've recoded the ArgumentParse#parseArguments method to handle commands with multiple optional arguments.
The idea behind what i've written is: Taking into consideration that the arguments are passed in order... When we encounter an optional argument we take the value from CommandArgs#next then we call DrinkProvider#provide and we catch if it throws CommandExitMessage, in case we get the value from CommandParameter#getDefaultOptionalValue and we call again DrinkProvider#provide and if it fails again will be just handle like before in the method that called ArgumentParse#parseArguments, otherwise we call CommandArgs#skip which basically reduce the index of CommandArgs by 1.