### PR TITLE
Add option to disable tab completion for specific commands

### DIFF
--- a/src/main/java/com/jonahseguin/drink/annotation/HideCommand.java
+++ b/src/main/java/com/jonahseguin/drink/annotation/HideCommand.java
@@ -1,0 +1,13 @@
+package com.jonahseguin.drink.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface HideCommand {
+
+
+}

--- a/src/main/java/com/jonahseguin/drink/command/DrinkCommandContainer.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkCommandContainer.java
@@ -1,6 +1,7 @@
 package com.jonahseguin.drink.command;
 
 import com.google.common.base.Preconditions;
+import com.jonahseguin.drink.annotation.HideCommand;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -51,10 +52,12 @@ public class DrinkCommandContainer extends Command implements PluginIdentifiable
         final String p = prefix.toLowerCase();
         List<String> suggestions = new ArrayList<>();
         for (DrinkCommand c : commands.values()) {
-            for (String alias : c.getAllAliases()) {
-                if (alias.length() > 0) {
-                    if (p.length() == 0 || alias.toLowerCase().startsWith(p)) {
-                        suggestions.add(alias);
+            if (!c.getMethod().isAnnotationPresent(HideCommand.class)) {
+                for (String alias : c.getAllAliases()) {
+                    if (alias.length() > 0) {
+                        if (p.length() == 0 || alias.toLowerCase().startsWith(p)) {
+                            suggestions.add(alias);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/jonahseguin/drink/command/DrinkHelpService.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkHelpService.java
@@ -1,5 +1,6 @@
 package com.jonahseguin.drink.command;
 
+import com.jonahseguin.drink.annotation.HideCommand;
 import lombok.Getter;
 import lombok.Setter;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -21,6 +22,10 @@ public class DrinkHelpService {
             sender.sendMessage(ChatColor.translateAlternateColorCodes('&', "&7&m--------------------------------"));
             sender.sendMessage(ChatColor.translateAlternateColorCodes('&', "&bHelp &7- &6/" + container.getName()));
             for (DrinkCommand c : container.getCommands().values()) {
+                if (c.getMethod().isAnnotationPresent(HideCommand.class)) {
+                    continue;
+                }
+
                 TextComponent msg = new TextComponent(net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&',
                         "&7/" + container.getName() + (c.getName().length() > 0 ? " &e" + c.getName() : "") + " &7" + c.getMostApplicableUsage() + " &7- &f" + c.getShortDescription()));
                 msg.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColor.GRAY + "/" + container.getName() + " " + c.getName() + " - " + ChatColor.WHITE + c.getDescription())));

--- a/src/main/java/com/jonahseguin/drink/command/DrinkTabCompleter.java
+++ b/src/main/java/com/jonahseguin/drink/command/DrinkTabCompleter.java
@@ -74,6 +74,7 @@ public class DrinkTabCompleter implements TabCompleter {
                 }
             }
         }
+
         return Collections.emptyList();
     }
 }


### PR DESCRIPTION
This pull allows users to utilize the @HideCommand annotation. 

When this annotation is applied to a DrinkCommand method, it will be removed from tab completion, 
and will not be displayed when doing /<command> help. This is useful when we want to hide certain commands from players.

For example, when we want to hide a reload command, it would look like this:
```java
package net.pinger.hynick.commands;

import com.jonahseguin.drink.annotation.Command;
import com.jonahseguin.drink.annotation.HideCommand;
import com.jonahseguin.drink.annotation.Require;
import com.jonahseguin.drink.annotation.Sender;
import net.pinger.hynick.SpigotHynickPlugin;
import org.bukkit.ChatColor;
import org.bukkit.command.CommandSender;

public class ReloadCommand {

    private final SpigotHynickPlugin plugin;

    public ReloadCommand(SpigotHynickPlugin plugin) {
        this.plugin = plugin;
    }

    @Command(name = "reload", usage = "reload", desc = "Reload configuration files of this plugin")
    @Require("hynick.reload")
    @HideCommand
    public void reload(@Sender CommandSender sender) {
        this.plugin.getFeatureManager().reload();
        sender.sendMessage(ChatColor.AQUA + "[Hynick] Reloaded configuration files.");
    }
}

```

